### PR TITLE
fix !important

### DIFF
--- a/docs.css
+++ b/docs.css
@@ -98,8 +98,8 @@
   margin-top: -2rem;
 }
 
-.intro-github {
-  color: var(--COLOR-BRAND-DARK) !important;
+.link.intro-github {
+  color: var(--COLOR-BRAND-DARK);
 }
 
 /** Link to Top **/


### PR DESCRIPTION
**fixed the `!important` issue with `specificity`.**

The issue was in [Introduction Page](https://github.com/hsnice16/PoshUI-Documentation/blob/development/pages/getting-started/introduction.html)

At line 168, 
![image](https://user-images.githubusercontent.com/56081584/153700471-93da1b50-8e99-4bdf-a930-7636df6c5ce9.png)

Why I was using `!important`?
![Posh-UI-_-Introduction-Getting-Started-and-5-more-pages-Personal-Microsoft_-Edge-2022-02-12-12-20-18](https://user-images.githubusercontent.com/56081584/153700831-23912078-be57-4f6c-9e05-adf39f57f409.gif)

As you can see (in the gif), the `<a>` color was changing in red, I wanted to keep its color the same for all the states. But I am also using class `link` on it (at line 168, in above img), which has some different colors (some other, which I did not want). But `link` class was defined below in the source order, in comparison to `intro-github` class, that's why I used `!important`.

But my mentor, [Vikram Santhalia](https://twitter.com/VikramSanthalia), told us we can replace `!important` with more `specificity`. It didn't come to my mind before while implementing this.

This was something new.

Please review this PR, and give your feedback.